### PR TITLE
Fix codecov/patch check also

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -4,3 +4,6 @@ coverage:
       default:
         target: 90%
         threshold: 3%
+    patch:
+      default:
+        target: 90%


### PR DESCRIPTION
`codecov/patch` check that automatically runs for each PR uses some strange threshold by default.

Fix it with `90%`.