### PR TITLE
JWT revocation must consider clock skew leeway to prevent timing attack

### DIFF
--- a/server/domain/channel.go
+++ b/server/domain/channel.go
@@ -17,6 +17,7 @@ type ChannelProvider interface {
 	Get(id ChannelID) (Channel, error)
 
 	GetFileDescriptorPressure() int
+	JWTClockSkewLeewayMax() Duration
 
 	Shutdown(ctx context.Context)
 }

--- a/server/domain/channel/cached_channel_provider_test.go
+++ b/server/domain/channel/cached_channel_provider_test.go
@@ -105,14 +105,18 @@ func TestCacheChannelError(t *testing.T) {
 	dspstesting.IsError(t, errToReturn, err)
 }
 
-func TestGetFileDescriptorPressure(t *testing.T) {
+func TestCachedProviderValues(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	inner := mock.NewMockChannelProvider(ctrl)
 	inner.EXPECT().GetFileDescriptorPressure().Return(1234).Times(1)
+	leeway := domain.Duration{Duration: 123 * time.Second}
+	inner.EXPECT().JWTClockSkewLeewayMax().Return(leeway).Times(1)
 
 	cp := newCachedChannelProvider(inner, domain.RealSystemClock)
 	assert.Equal(t, 1234, cp.GetFileDescriptorPressure())
 	assert.Equal(t, 1234, cp.GetFileDescriptorPressure())
+	assert.Equal(t, leeway, cp.JWTClockSkewLeewayMax())
+	assert.Equal(t, leeway, cp.JWTClockSkewLeewayMax())
 }

--- a/server/domain/channel/channel_atom.go
+++ b/server/domain/channel/channel_atom.go
@@ -73,6 +73,13 @@ func (c *channelAtom) GetFileDescriptorPressure() int {
 	return result
 }
 
+func (c *channelAtom) JWTClockSkewLeewayMax() domain.Duration {
+	if c.JwtValidatorTemplate == nil {
+		return domain.Duration{}
+	}
+	return c.JwtValidatorTemplate.JWTClockSkewLeewayMax()
+}
+
 func (c *channelAtom) validate() error {
 	if err := c.validateTemplateStrings(); err != nil {
 		return err

--- a/server/domain/channel/channel_provider.go
+++ b/server/domain/channel/channel_provider.go
@@ -60,6 +60,17 @@ func (cp *channelProvider) GetFileDescriptorPressure() int {
 	return result
 }
 
+func (cp *channelProvider) JWTClockSkewLeewayMax() domain.Duration {
+	var result domain.Duration
+	for _, atom := range cp.atoms {
+		d := atom.JWTClockSkewLeewayMax()
+		if result.Duration < d.Duration {
+			result = d
+		}
+	}
+	return result
+}
+
 func (cp *channelProvider) Get(id domain.ChannelID) (domain.Channel, error) {
 	found := make([]*channelAtom, 0, 4)
 	for _, atom := range cp.atoms {

--- a/server/jwt/validator/validator.go
+++ b/server/jwt/validator/validator.go
@@ -16,6 +16,7 @@ import (
 // Template is a template of Validator
 type Template interface {
 	NewValidator(tplEnv domain.TemplateStringEnv) (Validator, error)
+	JWTClockSkewLeewayMax() domain.Duration
 }
 
 type validatorTemplate struct {
@@ -85,6 +86,10 @@ func (v *validatorTemplate) NewValidator(tplEnv domain.TemplateStringEnv) (Valid
 		claims[claim] = strs
 	}
 	return &validator{validatorTemplate: *v, claims: claims}, nil
+}
+
+func (v *validatorTemplate) JWTClockSkewLeewayMax() domain.Duration {
+	return *v.cfg.ClockSkewLeeway
 }
 
 func (v *validator) Validate(ctx context.Context, jwt string) error {

--- a/server/jwt/validator/validator_test.go
+++ b/server/jwt/validator/validator_test.go
@@ -235,6 +235,8 @@ func TestClockLeeway(t *testing.T) {
 	v, err := tpl.NewValidator(struct{}{})
 	assert.NoError(t, err)
 
+	assert.Equal(t, domain.Duration{Duration: 300 * time.Second}, tpl.JWTClockSkewLeewayMax())
+
 	// Valid, within clock skew leeway
 	for _, testcase := range []struct {
 		NbfSec, IatSec, ExpSec time.Duration

--- a/server/testing/channel.go
+++ b/server/testing/channel.go
@@ -21,3 +21,8 @@ func (f ChannelProviderFunc) Get(id domain.ChannelID) (domain.Channel, error) {
 func (f ChannelProviderFunc) GetFileDescriptorPressure() int {
 	return 0
 }
+
+// JWTClockSkewLeewayMax implements ChannelProvider
+func (f ChannelProviderFunc) JWTClockSkewLeewayMax() domain.Duration {
+	return domain.Duration{}
+}


### PR DESCRIPTION
1. JWT validator accepts `now <= exp + clockSkewLeeway`
2. Storage implementations *can* forget revoked JWT after `exp`

As a result, it accepts JWT when `exp < now <= exp + clockSkewLeeway`. 

This PR is to fix this problem to change behavior `2` above. Store revoked JWT information until `now + clockSkewLeeway` at least.
