### PR TITLE
Make IdleTimeout controllable

### DIFF
--- a/server/config/http_server_config.go
+++ b/server/config/http_server_config.go
@@ -17,6 +17,7 @@ type HTTPServerConfig struct {
 	DiscloseAuthRejectionDetail bool              `json:"discloseAuthRejectionDetail"`
 	DefaultHeaders              map[string]string `json:"defaultHeaders"`
 
+	IdleTimeout             domain.Duration `json:"idleTimeout"`
 	ReadTimeout             domain.Duration `json:"readTimeout"`
 	WriteTimeout            domain.Duration `json:"writeTimeout"`
 	LongPollingMaxTimeout   domain.Duration `json:"longPollingMaxTimeout"`
@@ -27,6 +28,7 @@ func httpServerConfigDefault() *HTTPServerConfig {
 	return &HTTPServerConfig{
 		Port: 3000,
 
+		IdleTimeout:             makeDuration("1h30m"),
 		ReadTimeout:             makeDuration("10s"),
 		WriteTimeout:            makeDuration("60s"),
 		LongPollingMaxTimeout:   makeDuration("30s"),
@@ -60,6 +62,9 @@ func PostprocessHTTPServerConfig(config *HTTPServerConfig, overrides Overrides) 
 	if len(config.TrustedProxyRanges) == 0 {
 		config.TrustedProxyRanges = make([]domain.CIDR, len(domain.PrivateCIDRs))
 		copy(config.TrustedProxyRanges, domain.PrivateCIDRs)
+	}
+	if config.IdleTimeout.Duration == 0 {
+		config.IdleTimeout = httpServerConfigDefault().IdleTimeout
 	}
 	if config.ReadTimeout.Duration == 0 {
 		config.ReadTimeout = httpServerConfigDefault().ReadTimeout

--- a/server/config/http_server_config_test.go
+++ b/server/config/http_server_config_test.go
@@ -25,6 +25,7 @@ func TestHttpServerDefaultValues(t *testing.T) {
 	assert.Equal(t, len(domain.PrivateCIDRs), len(cfg.TrustedProxyRanges))
 	assert.Equal(t, domain.PrivateCIDRs[0].String(), cfg.TrustedProxyRanges[0].String())
 	assert.Equal(t, `deny`, cfg.DefaultHeaders["X-Frame-Options"])
+	assert.Equal(t, 90*time.Minute, cfg.IdleTimeout.Duration)
 	assert.Equal(t, 10*time.Second, cfg.ReadTimeout.Duration)
 	assert.Equal(t, 60*time.Second, cfg.WriteTimeout.Duration)
 	assert.Equal(t, 30*time.Second, cfg.LongPollingMaxTimeout.Duration)
@@ -39,6 +40,7 @@ http:
 		- 1.2.3.4/16
 	defaultHeaders:
 		X-Frame-Options:
+	idleTimeout: 123s
 	readTimeout: 1s
 	writeTimeout: 2s
 	longPollingMaxTimeout: 3s
@@ -55,6 +57,7 @@ http:
 	assert.Equal(t, 1, len(cfg.TrustedProxyRanges))
 	assert.Equal(t, "1.2.3.4/16", cfg.TrustedProxyRanges[0].String())
 	assert.Equal(t, ``, cfg.DefaultHeaders["X-Frame-Options"])
+	assert.Equal(t, 123*time.Second, cfg.IdleTimeout.Duration)
 	assert.Equal(t, 1*time.Second, cfg.ReadTimeout.Duration)
 	assert.Equal(t, 2*time.Second, cfg.WriteTimeout.Duration)
 	assert.Equal(t, 3*time.Second, cfg.LongPollingMaxTimeout.Duration)

--- a/server/doc/config.md
+++ b/server/doc/config.md
@@ -78,6 +78,7 @@ Configuration items under `http`:
   - `realIpHeader` only accepts header values from those ranges.
   - By default or if empty list given, allow [RFC 1918](https://tools.ietf.org/html/rfc1918) ranges `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` and [RFC 4193](https://tools.ietf.org/html/rfc4193) range `fc00::/7` and also `127.0.0.0/8` ([RFC 1122](https://tools.ietf.org/html/rfc1122#section-3.2.1.3)), `169.254.0.0/16` ([RFC 3927](https://tools.ietf.org/html/rfc3927)), `::1/128` and `fe80::/10` ([RFC 4291](https://tools.ietf.org/html/rfc4291)).
 - `discloseAuthRejectionDetail` (boolean, default `false`): Show detail reason of 403 to clients, **do not enable on production**
+- `idleTimeout` (duration string, default `1h30m`): Max duration to keep idle connection, should be larger than keep-alive duration of clients/loadbalancer.
 - `readTimeout` (duration string, default `10s`): Max duration to read request from clients.
 - `writeTimeout` (duration string, default `60s`): Max duration since end of request header reading until request processing completion
   - Note that server automatically add `longPollingMaxTimeout` to this value

--- a/server/http/webserver.go
+++ b/server/http/webserver.go
@@ -54,6 +54,7 @@ func runServer(mainContext context.Context, config *config.ServerConfig, engine 
 	srv := &http.Server{
 		Addr:           addr,
 		Handler:        engine,
+		IdleTimeout:    config.HTTPServer.IdleTimeout.Duration,
 		ReadTimeout:    config.HTTPServer.ReadTimeout.Duration,
 		WriteTimeout:   config.HTTPServer.LongPollingMaxTimeout.Duration + config.HTTPServer.WriteTimeout.Duration,
 		MaxHeaderBytes: 1 << 20,


### PR DESCRIPTION
Should set idleTimeout equal to or larger than keep-alive timeout of clients/loadbalancers.
