### PR TITLE
Redis storage should extend TTL on fetchMessages

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-redis/redis/extra/redisotel v0.2.0
 	github.com/go-redis/redis/v8 v8.4.0
 	github.com/goccy/go-yaml v1.8.4
-	github.com/golang/mock v1.4.4
+	github.com/golang/mock v1.5.0
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.1.2
 	github.com/julienschmidt/httprouter v1.3.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -141,6 +141,8 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
+github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
+github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/server/storage/redis/channel_ttl.go
+++ b/server/storage/redis/channel_ttl.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"math"
 	"strconv"
+	"time"
 
 	"github.com/saiya/dsps/server/domain"
 )
@@ -12,6 +13,10 @@ type channelTTLSec int64
 // go-redis depends on BinaryMarshaler
 func (c channelTTLSec) MarshalBinary() (data []byte, err error) {
 	return []byte(strconv.FormatInt(int64(c), 10)), nil
+}
+
+func (c channelTTLSec) asDuration() time.Duration {
+	return time.Duration(c) * time.Second
 }
 
 func (s *redisStorage) channelRedisTTLSec(channelID domain.ChannelID) (channelTTLSec, error) {

--- a/server/storage/redis/internal/redis_command.go
+++ b/server/storage/redis/internal/redis_command.go
@@ -22,6 +22,8 @@ type RedisCmd interface {
 	Get(ctx context.Context, key string) (*string, error)
 	MGet(ctx context.Context, keys ...string) ([]*string, error)
 	TTL(ctx context.Context, key string) (*time.Duration, error)
+	// EXPIRE command set TTL of the entry, not discarding the entry (name came from https://redis.io/commands/expire)
+	Expire(ctx context.Context, key string, ttl time.Duration) error
 	Set(ctx context.Context, key string, value interface{}) error
 	SetEX(ctx context.Context, key string, value interface{}, expiration time.Duration) error
 	Del(ctx context.Context, key string) error
@@ -88,6 +90,10 @@ func (impl *redisCmdImpl) TTL(ctx context.Context, key string) (*time.Duration, 
 		return nil, nil
 	}
 	return &value, err
+}
+
+func (impl *redisCmdImpl) Expire(ctx context.Context, key string, ttl time.Duration) error {
+	return impl.raw.Expire(ctx, key, ttl).Err()
 }
 
 func (impl *redisCmdImpl) Set(ctx context.Context, key string, value interface{}) error {

--- a/server/storage/redis/pubsub_subscriber_test.go
+++ b/server/storage/redis/pubsub_subscriber_test.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/saiya/dsps/server/domain"
+	storagetesting "github.com/saiya/dsps/server/storage/testing"
 	dspstesting "github.com/saiya/dsps/server/testing"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRemoveSubscriberError(t *testing.T) {
@@ -24,4 +26,35 @@ func TestRemoveSubscriberError(t *testing.T) {
 
 	err := s.RemoveSubscriber(context.Background(), sl)
 	dspstesting.IsError(t, errToReturn, err)
+}
+
+func TestExtendSubscriberTTLSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ch := randomChannelID(t)
+	sl := domain.SubscriberLocator{ChannelID: ch, SubscriberID: "sbsc-1"}
+	keys := keyOfChannel(ch)
+
+	s, redisCmd := newMockedRedisStorage(ctrl)
+	redisCmd.EXPECT().Expire(gomock.Any(), keys.Clock(), storagetesting.StubChannelExpire.Duration+ttlMargin).Return(nil)
+	redisCmd.EXPECT().Expire(gomock.Any(), keys.SubscriberCursor(sl.SubscriberID), storagetesting.StubChannelExpire.Duration+ttlMargin).Return(nil)
+
+	assert.NoError(t, s.extendSubscriberTTL(context.Background(), sl))
+}
+
+func TestExtendSubscriberTTLError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ch := randomChannelID(t)
+	sl := domain.SubscriberLocator{ChannelID: ch, SubscriberID: "sbsc-1"}
+	keys := keyOfChannel(ch)
+
+	s, redisCmd := newMockedRedisStorage(ctrl)
+	errToReturn := errors.New("Mocked redis error")
+	redisCmd.EXPECT().Expire(gomock.Any(), keys.Clock(), storagetesting.StubChannelExpire.Duration+ttlMargin).Return(errToReturn)
+	redisCmd.EXPECT().Expire(gomock.Any(), keys.SubscriberCursor(sl.SubscriberID), storagetesting.StubChannelExpire.Duration+ttlMargin).Return(errToReturn)
+
+	dspstesting.IsError(t, errToReturn, s.extendSubscriberTTL(context.Background(), sl))
 }

--- a/server/storage/testing/channel.go
+++ b/server/storage/testing/channel.go
@@ -11,6 +11,9 @@ import (
 // DisabledChannelID is ChannelID that StubChannelProvider always rejects.
 var DisabledChannelID domain.ChannelID = "disabled-channel"
 
+// StubChannelExpire is expire (TTL) of any channels pro
+var StubChannelExpire = dspstesting.MakeDuration("5m")
+
 // StubChannelProvider is simple stub implementation of ChannelProvider
 var StubChannelProvider domain.ChannelProvider = dspstesting.ChannelProviderFunc(func(id domain.ChannelID) (domain.Channel, error) {
 	if id == DisabledChannelID {
@@ -18,7 +21,7 @@ var StubChannelProvider domain.ChannelProvider = dspstesting.ChannelProviderFunc
 	}
 	return &stubChannel{
 		id:     id,
-		expire: dspstesting.MakeDuration("5m"),
+		expire: StubChannelExpire,
 	}, nil
 })
 


### PR DESCRIPTION
If no messages sent to a channel for long time (> expire period), Redis automatically invalidate channel clock entry and subscriber clock entry because TTL passed.

To prevent those entries to be invalidated, need to extend TTL on fetch operation.

Because subscriber should fetch messages periodically, this fix resolves the invalidation problem.